### PR TITLE
Added onError block

### DIFF
--- a/app/src/main/java/com/mindorks/framework/mvp/ui/feed/blog/presenter/BlogPresenter.kt
+++ b/app/src/main/java/com/mindorks/framework/mvp/ui/feed/blog/presenter/BlogPresenter.kt
@@ -17,12 +17,12 @@ class BlogPresenter<V : BlogMVPView, I : BlogMVPInteractor> @Inject constructor(
         interactor?.let {
             it.getBlogList()
                     .compose(schedulerProvider.ioToMainObservableScheduler())
-                    .subscribe { blogResponse ->
+                    .subscribe({ blogResponse ->
                         getView()?.let {
                             it.hideProgress()
                             it.displayBlogList(blogResponse.data)
                         }
-                    }
+                    }, { err -> println(err) })
         }
     }
 }


### PR DESCRIPTION
Navigating to the Feed page caused crash as onError block was not implemented. Fixed the same.